### PR TITLE
Fix file drop handler

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1012,7 +1012,9 @@ class PolyHueApp {
         
         const files = event.dataTransfer.files;
         if (files.length > 0) {
-            this.elements.imageInput.files = files;
+            // Directly forward the file list to the upload handler.
+            // The `files` property of an input element is read‑only,
+            // so we cannot assign to `this.elements.imageInput.files`.
             this.handleImageUpload({ target: { files } });
         }
     }


### PR DESCRIPTION
## Summary
- fix drop handler so it doesn't attempt to set the read-only `files` property

## Testing
- `node -e "require('./js/main.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68764e41805083238862f01ebab184dc