### PR TITLE
Fix corrupted text in overview

### DIFF
--- a/.cursor/rules/00-overview.mdc
+++ b/.cursor/rules/00-overview.mdc
@@ -31,4 +31,4 @@ When generating code or explanations:
 
 
 # Local Setup
-We are in a wsl environment so if you want to execute command do not forget about this.
+We are in a WSL environment, so keep that in mind when running commands.


### PR DESCRIPTION
## Summary
- clean up local setup notes

## Testing
- `od -c .cursor/rules/00-overview.mdc | tail`

------
https://chatgpt.com/codex/tasks/task_e_6876517013cc8323b49fe61abed52a15